### PR TITLE
28084 handle failures

### DIFF
--- a/dennis_link_checker.module
+++ b/dennis_link_checker.module
@@ -9,6 +9,8 @@ use Dennis\Link\Checker\LinkLocalisation;
 use Dennis\Link\Checker\Processor;
 use Dennis\Link\Checker\EntityHandler;
 use Dennis\Link\Checker\Analyzer;
+use Dennis\Link\Checker\Throttler;
+use Dennis\Link\Checker\Database;
 use SystemQueue as Queue;
 
 /**
@@ -41,7 +43,14 @@ function dennis_link_checker_setup(array $nids) {
 
   $queue = new Queue('dennis_link_checker');
   $entity_handler = new EntityHandler($config);
-  $analyzer = new Analyzer($config);
+
+  // Make sure we don't request more than one page per second.
+  $curl_throttler = new Throttler(1);
+
+  // Database object that allows interaction with the DB.
+  $database = new Database();
+
+  $analyzer = new Analyzer($config, $curl_throttler, $database);
   return new Processor($config, $queue, $entity_handler, $analyzer);
 }
 

--- a/dennis_link_checker.module
+++ b/dennis_link_checker.module
@@ -11,7 +11,7 @@ use Dennis\Link\Checker\EntityHandler;
 use Dennis\Link\Checker\Analyzer;
 use Dennis\Link\Checker\Throttler;
 use Dennis\Link\Checker\Database;
-use SystemQueue as Queue;
+use Dennis\Link\Checker\Queue;
 
 /**
  * PSR-4 autoloader

--- a/src/Dennis/Link/Checker/Analyzer.php
+++ b/src/Dennis/Link/Checker/Analyzer.php
@@ -21,7 +21,7 @@ class Analyzer implements AnalyzerInterface {
   /**
    * @var int maximum number of seconds to spend resolving links.
    */
-  protected $linkTimeLimit = 300;
+  protected $linkTimeLimit = 480;
 
   /**
    * @var Throttler
@@ -83,6 +83,9 @@ class Analyzer implements AnalyzerInterface {
    * @inheritDoc
    */
   public function link(LinkInterface $link) {
+    // Make sure we only process one link per configured number of seconds.
+    $this->curlThrottler->throttle();
+
     // Only redirect 301's so cannot use CURLOPT_FOLLOWLOCATION
     $this->redirectCount = 0;
 
@@ -141,9 +144,6 @@ class Analyzer implements AnalyzerInterface {
    * @return array
    */
   protected function getInfo($url) {
-    // Make sure we don't request more more than configured number of seconds.
-    $this->curlThrottler->throttle();
-
     // Only redirect 301's so cannot use CURLOPT_FOLLOWLOCATION
     $ch = curl_init();
     curl_setopt($ch, CURLOPT_URL, $url);

--- a/src/Dennis/Link/Checker/Analyzer.php
+++ b/src/Dennis/Link/Checker/Analyzer.php
@@ -18,10 +18,16 @@ class Analyzer implements AnalyzerInterface {
   protected $redirectCount;
 
   /**
+   * @var Throttler
+   */
+  protected $throttler;
+
+  /**
    * @inheritDoc
    */
   public function __construct(ConfigInterface $config) {
     $this->config = $config;
+    $this->throttler = new Throttler();
   }
 
   /**
@@ -108,6 +114,9 @@ class Analyzer implements AnalyzerInterface {
    * @return array
    */
   protected function getInfo($url) {
+    // Make sure we don't request more than one page per second.
+    $this->throttler->throttle(1);
+
     // Only redirect 301's so cannot use CURLOPT_FOLLOWLOCATION
     $ch = curl_init();
     curl_setopt($ch, CURLOPT_URL, $url);

--- a/src/Dennis/Link/Checker/AnalyzerInterface.php
+++ b/src/Dennis/Link/Checker/AnalyzerInterface.php
@@ -13,9 +13,12 @@ interface AnalyzerInterface {
 
   /**
    * AnalyzerInterface constructor.
+   *
    * @param ConfigInterface $config
+   * @param Throttler $curl_throttler
+   * @param Database $database
    */
-  public function __construct(ConfigInterface $config);
+  public function __construct(ConfigInterface $config, Throttler $curl_throttler, Database $database);
 
   /**
    * Checks the link.

--- a/src/Dennis/Link/Checker/Database.php
+++ b/src/Dennis/Link/Checker/Database.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * @file
+ * Database
+ */
+namespace Dennis\Link\Checker;
+
+/**
+ * Class Database
+ * @package Dennis\Link\Database
+ */
+class Database implements DatabaseInterface {
+  /**
+   * How often the DB should be pinged in seconds.
+   */
+  const interval = 15;
+
+  /**
+   * @var int last time the DB was pinged.
+   */
+  protected $pingTime = 0;
+
+  /**
+   * @inheritDoc
+   */
+  public function keepConnectionAlive() {
+    $now = time();
+    // If it's been more than 15 seconds... Ping!
+    if (($now - $this->pingTime) > self::interval) {
+      echo 'Keeping DB connection alive';
+      db_query('SELECT CURTIME()');
+      // Set the ping time.
+      $this->pingTime = $now;
+    }
+  }
+}

--- a/src/Dennis/Link/Checker/Database.php
+++ b/src/Dennis/Link/Checker/Database.php
@@ -27,7 +27,6 @@ class Database implements DatabaseInterface {
     $now = time();
     // If it's been more than 15 seconds... Ping!
     if (($now - $this->pingTime) > self::interval) {
-      echo 'Keeping DB connection alive';
       db_query('SELECT CURTIME()');
       // Set the ping time.
       $this->pingTime = $now;

--- a/src/Dennis/Link/Checker/DatabaseInterface.php
+++ b/src/Dennis/Link/Checker/DatabaseInterface.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * @file
+ * DatabaseInterface
+ */
+namespace Dennis\Link\Checker;
+
+/**
+ * Interface DatabaseInterface
+ * @package Dennis\Link\Checker
+ */
+interface DatabaseInterface {
+  /**
+   * Keep database connection alive.
+   */
+  public function keepConnectionAlive();
+}

--- a/src/Dennis/Link/Checker/EntityHandler.php
+++ b/src/Dennis/Link/Checker/EntityHandler.php
@@ -99,11 +99,13 @@ class EntityHandler implements EntityHandlerInterface {
 
     $query = db_select('field_data_' . $link->entityField(), 't');
     $query->addField('t', $value_field);
+    $query->addField('t', 'revision_id');
     $query->condition('entity_id', $link->entityId());
     $query->condition('entity_type', $link->entityType());
 
     $result = $query->execute()->fetchObject();
     $text = $result->{$value_field};
+    $revision_id = $result->revision_id;
 
     $correction = $link->correctedHref();
 
@@ -140,13 +142,16 @@ class EntityHandler implements EntityHandlerInterface {
       }
     }
 
-    db_update('field_data_' . $link->entityField())
-      ->fields(array(
-        $value_field => $updated_text
-      ))
-      ->condition('entity_id', $link->entityId())
-      ->condition('entity_type', $link->entityType())
-      ->execute();
+    foreach (array('data', 'revision') as $table_type) {
+      $rows = db_update('field_' . $table_type . '_' . $link->entityField())
+        ->fields(array(
+          $value_field => $updated_text
+        ))
+        ->condition('entity_id', $link->entityId())
+        ->condition('entity_type', $link->entityType())
+        ->condition('revision_id', $revision_id)
+        ->execute();
+    }
   }
 
   /**

--- a/src/Dennis/Link/Checker/EntityHandler.php
+++ b/src/Dennis/Link/Checker/EntityHandler.php
@@ -63,6 +63,7 @@ class EntityHandler implements EntityHandlerInterface {
     $dom = filter_dom_load($text);
 
     $links = $dom->getElementsByTagName('a');
+
     foreach ($links as $link) {
       $href = $link->getAttribute('href');
       if ($this->config->internalOnly()) {

--- a/src/Dennis/Link/Checker/EntityHandler.php
+++ b/src/Dennis/Link/Checker/EntityHandler.php
@@ -41,10 +41,10 @@ class EntityHandler implements EntityHandlerInterface {
    */
   public function findLinks($entity_type, $entity_id) {
 
-    $field_name = 'field_data_body';
-    $value_field = 'body_value';
+    $field_name = 'body';
+    $value_field = $field_name . '_value';
 
-    $query = db_select($field_name, 't');
+    $query = db_select('field_data_' . $field_name, 't');
     $query->addField('t', $value_field);
     $query->condition('entity_id', $entity_id);
     $query->condition('entity_type', $entity_type);
@@ -95,9 +95,9 @@ class EntityHandler implements EntityHandlerInterface {
    */
   public function updateLink(LinkInterface $link) {
 
-    $value_field = 'body_value'; //@todo not hard coded
+    $value_field = $link->entityField() . '_value';
 
-    $query = db_select($link->entityField(), 't');
+    $query = db_select('field_data_' . $link->entityField(), 't');
     $query->addField('t', $value_field);
     $query->condition('entity_id', $link->entityId());
     $query->condition('entity_type', $link->entityType());
@@ -140,7 +140,7 @@ class EntityHandler implements EntityHandlerInterface {
       }
     }
 
-    db_update($link->entityField())
+    db_update('field_data_' . $link->entityField())
       ->fields(array(
         $value_field => $updated_text
       ))

--- a/src/Dennis/Link/Checker/Processor.php
+++ b/src/Dennis/Link/Checker/Processor.php
@@ -44,6 +44,12 @@ class Processor implements ProcessorInterface {
    * @inheritDoc
    */
   public function run() {
+    // Prevent processing of links when site is in maintenance mode.
+    if (variable_get('maintenance_mode', 0)) {
+      $this->config->getLogger()->info('Links cannot be processed when the site is in maintenance mode.');
+      return;
+    }
+
     $end = time() + $this->timeLimit;
 
     // Remove any old items from the queue.

--- a/src/Dennis/Link/Checker/Processor.php
+++ b/src/Dennis/Link/Checker/Processor.php
@@ -52,7 +52,6 @@ class Processor implements ProcessorInterface {
     $more = TRUE;
     while ($more && time() < $end) {
       $more = $this->doNextItem();
-      sleep(1);
     }
   }
 

--- a/src/Dennis/Link/Checker/Processor.php
+++ b/src/Dennis/Link/Checker/Processor.php
@@ -46,6 +46,9 @@ class Processor implements ProcessorInterface {
   public function run() {
     $end = time() + $this->timeLimit;
 
+    // Remove any old items from the queue.
+    $this->queue->prune();
+
     // Make sure there is something to do.
     $this->ensureEnqueued();
 

--- a/src/Dennis/Link/Checker/Queue.php
+++ b/src/Dennis/Link/Checker/Queue.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * @file
+ * Queue
+ */
+namespace Dennis\Link\Checker;
+
+/**
+ * Class Queue
+ * @package Dennis\Link\Checker
+ */
+class Queue extends \SystemQueue implements QueueInterface {
+  /**
+   * Remove any items from the queue that have been claimed but not deleted.
+   */
+  public function prune() {
+    db_delete('queue')
+      ->condition('name', $this->name)
+      ->condition('expire', 0, '>')
+      ->execute();
+  }
+}

--- a/src/Dennis/Link/Checker/QueueInterface.php
+++ b/src/Dennis/Link/Checker/QueueInterface.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * @file
+ * QueueInterface
+ */
+namespace Dennis\Link\Checker;
+
+/**
+ * Class QueueInterface
+ * @package Dennis\Link\Checker
+ */
+interface QueueInterface {
+  /**
+   * Removes old items from the queue.
+   */
+  public function prune();
+}

--- a/src/Dennis/Link/Checker/Throttler.php
+++ b/src/Dennis/Link/Checker/Throttler.php
@@ -16,10 +16,23 @@ class Throttler implements ThrottlerInterface {
   protected $startTime = 0;
 
   /**
+   * @var int number of seconds to throttle for.
+   */
+  protected $seconds;
+
+  /**
+   * Throttler constructor.
+   * @param $seconds
+   */
+  public function __construct($seconds) {
+    $this->seconds = $seconds;
+  }
+
+  /**
    * @inheritDoc
    */
-  public function throttle($seconds) {
-    $wait_until = $this->startTime + $seconds;
+  public function throttle() {
+    $wait_until = $this->startTime + $this->seconds;
     if (microtime(TRUE) < $wait_until) {
       usleep(($wait_until - microtime(TRUE)) * 1000000);
     }

--- a/src/Dennis/Link/Checker/Throttler.php
+++ b/src/Dennis/Link/Checker/Throttler.php
@@ -7,7 +7,7 @@ namespace Dennis\Link\Checker;
 
 /**
  * Class Throttler
- * @package Dennis\Link\Throttler
+ * @package Dennis\Link\Checker
  */
 class Throttler implements ThrottlerInterface {
   /**

--- a/src/Dennis/Link/Checker/Throttler.php
+++ b/src/Dennis/Link/Checker/Throttler.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * @file
+ * Throttler
+ */
+namespace Dennis\Link\Checker;
+
+/**
+ * Class Throttler
+ * @package Dennis\Link\Throttler
+ */
+class Throttler implements ThrottlerInterface {
+  /**
+   * @var
+   */
+  protected $startTime = 0;
+
+  /**
+   * @inheritDoc
+   */
+  public function throttle($seconds) {
+    $wait_until = $this->startTime + $seconds;
+    if (microtime(TRUE) < $wait_until) {
+      usleep(($wait_until - microtime(TRUE)) * 1000000);
+    }
+    $this->startTime = microtime(TRUE);
+  }
+}

--- a/src/Dennis/Link/Checker/ThrottlerInterface.php
+++ b/src/Dennis/Link/Checker/ThrottlerInterface.php
@@ -12,8 +12,6 @@ namespace Dennis\Link\Checker;
 interface ThrottlerInterface {
   /**
    * Waits until throttle period has passed.
-   *
-   * @param int $seconds
    */
-  public function throttle($seconds);
+  public function throttle();
 }

--- a/src/Dennis/Link/Checker/ThrottlerInterface.php
+++ b/src/Dennis/Link/Checker/ThrottlerInterface.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * @file
+ * ThrottlerInterface
+ */
+namespace Dennis\Link\Checker;
+
+/**
+ * Interface ThrottlerInterface
+ * @package Dennis\Link\Checker
+ */
+interface ThrottlerInterface {
+  /**
+   * Waits until throttle period has passed.
+   *
+   * @param int $seconds
+   */
+  public function throttle($seconds);
+}

--- a/src/Dennis/Link/Checker/TimeoutException.php
+++ b/src/Dennis/Link/Checker/TimeoutException.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @file
+ * TimeoutException
+ */
+namespace Dennis\Link\Checker;
+
+/**
+ * Class TimeoutException
+ * @package Dennis\Link\Checker
+ */
+class TimeoutException extends \Exception {
+
+  /**
+   * TimeoutException constructor.
+   *
+   * @param null $message
+   * @param int $code
+   * @param \Exception|NULL $previous
+   */
+  public function __construct($message = NULL, $code = 0, \Exception $previous = NULL) {
+    parent::__construct($message, $code, $previous);
+  }
+
+}


### PR DESCRIPTION
**Summary of fixes:**

- Throttling each link, rather than each node. I'm not throttling per cURL request as chained redirects would become quite slow to process, and the default cURL behaviour would have been to follow in once go
- Keeping DB alive by "pinging" the DB with a query that gets the current time
- Added a timeout per node of 8 minutes – this seemed to be enough for an article with 200+ links (the one that is currently stuck)
- Preventing processing of links when site is in maintenance mode
- Updating current revision DB row (was only updating data table)