### PR TITLE
28312 performance

### DIFF
--- a/src/Dennis/Link/Checker/Analyzer.php
+++ b/src/Dennis/Link/Checker/Analyzer.php
@@ -6,7 +6,7 @@
 namespace Dennis\Link\Checker;
 
 /**
- * Class Corrector
+ * Class Analyzer
  * @package Dennis\Link\Checker
  */
 class Analyzer implements AnalyzerInterface {

--- a/src/Dennis/Link/Checker/AnalyzerInterface.php
+++ b/src/Dennis/Link/Checker/AnalyzerInterface.php
@@ -25,6 +25,7 @@ interface AnalyzerInterface {
    *
    * @param $link LinkInterface
    * @return string
+   * @thows RequestTimeoutException
    */
   public function link(LinkInterface $link);
 

--- a/src/Dennis/Link/Checker/Processor.php
+++ b/src/Dennis/Link/Checker/Processor.php
@@ -92,6 +92,9 @@ class Processor implements ProcessorInterface {
     return $this->queue;
   }
 
+  /**
+   * Removes old items.
+   */
   public function prune() {
     $this->getQueue()->prune();
   }

--- a/src/Dennis/Link/Checker/Processor.php
+++ b/src/Dennis/Link/Checker/Processor.php
@@ -258,7 +258,7 @@ class Processor implements ProcessorInterface {
       $field = $this->getEntityHandler()
         ->getEntity($item->entityType(), $item->entityId())
         ->getField($item->fieldName());
-        $this->correctLinks($item, $field);
+      $this->correctLinks($item, $field);
     }
   }
 

--- a/src/Dennis/Link/Checker/Processor.php
+++ b/src/Dennis/Link/Checker/Processor.php
@@ -40,7 +40,7 @@ class Processor implements ProcessorInterface {
     DrupalReliableQueueInterface $queue,
     EntityHandlerInterface $entity_handler,
     AnalyzerInterface $analyzer) {
-      $this->config = $config;
+      $this->setConfig($config);
       $this->setQueue($queue);
       $this->setEntityHandler($entity_handler);
       $this->setAnalyzer($analyzer);
@@ -51,15 +51,15 @@ class Processor implements ProcessorInterface {
    */
   public function run() {
     // Prevent processing of links when site is in maintenance mode.
-    if (variable_get('maintenance_mode', 0)) {
+    if ($this->inMaintenanceMode()) {
       $this->config->getLogger()->info('Links cannot be processed when the site is in maintenance mode.');
-      return;
+      return FALSE;
     }
 
     $end = time() + $this->timeLimit;
 
     // Remove any old items from the queue.
-    $this->queue->prune();
+    $this->prune();
 
     // Make sure there is something to do.
     $this->ensureEnqueued();
@@ -71,9 +71,18 @@ class Processor implements ProcessorInterface {
       } catch (RequestTimeoutException $e) {
         // Don't try to process any more items for this run.
         $this->config->getLogger()->warning($e->getMessage());
-        return;
+        return FALSE;
       }
     }
+
+    return TRUE;
+  }
+
+  /**
+   * Whether the site is in maintenance mode.
+   */
+  public function inMaintenanceMode() {
+    return variable_get('maintenance_mode', 0);
   }
 
   /**
@@ -81,6 +90,10 @@ class Processor implements ProcessorInterface {
    */
   public function getQueue() {
     return $this->queue;
+  }
+
+  public function prune() {
+    $this->getQueue()->prune();
   }
 
   /**
@@ -95,6 +108,13 @@ class Processor implements ProcessorInterface {
    */
   public function getTimeLimit() {
     return $this->timeLimit;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function setConfig(ConfigInterface $config) {
+    $this->config = $config;
   }
 
   /**

--- a/src/Dennis/Link/Checker/Processor.php
+++ b/src/Dennis/Link/Checker/Processor.php
@@ -66,7 +66,13 @@ class Processor implements ProcessorInterface {
 
     $more = TRUE;
     while ($more && time() < $end) {
-      $more = $this->doNextItem();
+      try {
+        $more = $this->doNextItem();
+      } catch (RequestTimeoutException $e) {
+        // Don't try to process any more items for this run.
+        $this->config->getLogger()->warning($e->getMessage());
+        return;
+      }
     }
   }
 
@@ -229,7 +235,7 @@ class Processor implements ProcessorInterface {
       $field = $this->getEntityHandler()
         ->getEntity($item->entityType(), $item->entityId())
         ->getField($item->fieldName());
-      $this->correctLinks($item, $field);
+        $this->correctLinks($item, $field);
     }
   }
 

--- a/src/Dennis/Link/Checker/ProcessorInterface.php
+++ b/src/Dennis/Link/Checker/ProcessorInterface.php
@@ -46,9 +46,17 @@ interface ProcessorInterface {
   /**
    * Processes the queue.
    *
-   * @return ProcessorInterface
+   * @return boolean
    */
   public function run();
+
+  /**
+   * The configuration object.
+   *
+   * @param ConfigInterface $config
+   * @return self
+   */
+  public function setConfig(ConfigInterface $config);
 
   /**
    * The queue to process.

--- a/src/Dennis/Link/Checker/RequestTimeoutException.php
+++ b/src/Dennis/Link/Checker/RequestTimeoutException.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @file
+ * RequestTimeoutException
+ */
+namespace Dennis\Link\Checker;
+
+/**
+ * Class RequestTimeoutException
+ * @package Dennis\Link\Checker
+ */
+class RequestTimeoutException extends \Exception {
+
+  /**
+   * RequestTimeoutException constructor.
+   *
+   * @param null $message
+   * @param int $code
+   * @param \Exception|NULL $previous
+   */
+  public function __construct($message = NULL, $code = 0, \Exception $previous = NULL) {
+    parent::__construct($message, $code, $previous);
+  }
+
+}

--- a/tests/Unit/Dennis/Link/Checker/AnalyzerTest.php
+++ b/tests/Unit/Dennis/Link/Checker/AnalyzerTest.php
@@ -19,7 +19,7 @@ class AnalyzerTest extends PHPUnitTestCase {
   /**
    * @covers ::getInfo
    */
-  public function testGetLinks() {
+  public function testGetInfo() {
     $analyzer = $this->getMockBuilder(Analyzer::class)
       ->disableOriginalConstructor()
       ->setMethods(['doInfoRequest'])
@@ -41,7 +41,7 @@ class AnalyzerTest extends PHPUnitTestCase {
    * @covers ::getInfo
    * @expectedException \Exception
    */
-  public function testGetLinksException() {
+  public function testGetInfoException() {
     // Check the exception is thrown.
     $analyzer = $this->getMockBuilder(Analyzer::class)
       ->disableOriginalConstructor()
@@ -51,6 +51,26 @@ class AnalyzerTest extends PHPUnitTestCase {
     $analyzer->method('doInfoRequest')->willThrowException($data);
     $url = 'http://example.com';
     $analyzer->getInfo($url);
+  }
+
+  /**
+   * @covers ::link
+   * @expectedException \Dennis\Link\Checker\RequestTimeoutException
+   */
+  public function testLinkException() {
+    $analyzer = $this->getMockBuilder(Analyzer::class)
+      ->disableOriginalConstructor()
+      ->setMethods(['doInfoRequest', 'throttle', 'getSiteHost'])
+      ->getMock();
+    $data = new RequestTimeoutException('timeout test', CURLOPT_TIMEOUT);
+    $analyzer->method('throttle')->willReturn(TRUE);
+    $analyzer->method('getSiteHost')->willReturn('example.com');
+    $analyzer->method('doInfoRequest')->willThrowException($data);
+
+    $link = $this->getMockBuilder(Link::class)
+      ->disableOriginalConstructor()
+      ->getMock();
+    $analyzer->link($link);
   }
 
 }

--- a/tests/Unit/Dennis/Link/Checker/AnalyzerTest.php
+++ b/tests/Unit/Dennis/Link/Checker/AnalyzerTest.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * @file
+ * Tests for Analyzer
+ */
+namespace Dennis\Link\Checker;
+
+// Use our mocked versions of some global functions.
+include_once 'global_functions.php';
+
+use PHPUnit\Framework\TestCase as PHPUnitTestCase;
+
+/**
+ * Class FieldTest
+ * @package Dennis/Link/Checker
+ */
+class AnalyzerTest extends PHPUnitTestCase {
+
+  /**
+   * @covers ::getInfo
+   */
+  public function testGetLinks() {
+    $analyzer = $this->getMockBuilder(Analyzer::class)
+      ->disableOriginalConstructor()
+      ->setMethods(['doInfoRequest'])
+      ->getMock();
+    $analyzer->method('doInfoRequest')->willReturn(['http_code' => '200']);
+
+    $this->assertEquals(['http_code' => '200'], $analyzer->getInfo('http://example.com'));
+  }
+
+}

--- a/tests/Unit/Dennis/Link/Checker/AnalyzerTest.php
+++ b/tests/Unit/Dennis/Link/Checker/AnalyzerTest.php
@@ -5,9 +5,6 @@
  */
 namespace Dennis\Link\Checker;
 
-// Use our mocked versions of some global functions.
-include_once 'global_functions.php';
-
 use PHPUnit\Framework\TestCase as PHPUnitTestCase;
 
 /**

--- a/tests/Unit/Dennis/Link/Checker/AnalyzerTest.php
+++ b/tests/Unit/Dennis/Link/Checker/AnalyzerTest.php
@@ -39,7 +39,7 @@ class AnalyzerTest extends PHPUnitTestCase {
 
   /**
    * @covers ::getInfo
-   * @expectedException \Exception
+   * @expectedException \Dennis\Link\Checker\ResourceFailException
    */
   public function testGetInfoException() {
     // Check the exception is thrown.
@@ -47,7 +47,7 @@ class AnalyzerTest extends PHPUnitTestCase {
       ->disableOriginalConstructor()
       ->setMethods(['doInfoRequest'])
       ->getMock();
-    $data = new \Exception('test', 42);
+    $data = new ResourceFailException('test', 42);
     $analyzer->method('doInfoRequest')->willThrowException($data);
     $url = 'http://example.com';
     $analyzer->getInfo($url);

--- a/tests/Unit/Dennis/Link/Checker/AnalyzerTest.php
+++ b/tests/Unit/Dennis/Link/Checker/AnalyzerTest.php
@@ -8,7 +8,7 @@ namespace Dennis\Link\Checker;
 use PHPUnit\Framework\TestCase as PHPUnitTestCase;
 
 /**
- * Class FieldTest
+ * Class AnalyzerTest
  * @package Dennis/Link/Checker
  */
 class AnalyzerTest extends PHPUnitTestCase {

--- a/tests/Unit/Dennis/Link/Checker/AnalyzerTest.php
+++ b/tests/Unit/Dennis/Link/Checker/AnalyzerTest.php
@@ -24,9 +24,33 @@ class AnalyzerTest extends PHPUnitTestCase {
       ->disableOriginalConstructor()
       ->setMethods(['doInfoRequest'])
       ->getMock();
-    $analyzer->method('doInfoRequest')->willReturn(['http_code' => '200']);
 
-    $this->assertEquals(['http_code' => '200'], $analyzer->getInfo('http://example.com'));
+    // Mock the method that does the http request.
+    $data = ['http_code' => '200'];
+    $analyzer->method('doInfoRequest')->willReturn($data);
+
+    // Check the static cache works,
+    // by insuring the method that makes the actual request is called only once.
+    $url = 'http://example.com';
+    $analyzer->expects($this->once())->method('doInfoRequest')->with($url);
+    $this->assertEquals($data, $analyzer->getInfo($url));
+    $this->assertEquals($data, $analyzer->getInfo($url));
+  }
+
+  /**
+   * @covers ::getInfo
+   * @expectedException \Exception
+   */
+  public function testGetLinksException() {
+    // Check the exception is thrown.
+    $analyzer = $this->getMockBuilder(Analyzer::class)
+      ->disableOriginalConstructor()
+      ->setMethods(['doInfoRequest'])
+      ->getMock();
+    $data = new \Exception('test', 42);
+    $analyzer->method('doInfoRequest')->willThrowException($data);
+    $url = 'http://example.com';
+    $analyzer->getInfo($url);
   }
 
 }

--- a/tests/Unit/Dennis/Link/Checker/ProcessorTest.php
+++ b/tests/Unit/Dennis/Link/Checker/ProcessorTest.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * @file
+ * Tests for Processor
+ */
+namespace Dennis\Link\Checker;
+
+use PHPUnit\Framework\TestCase as PHPUnitTestCase;
+
+
+/**
+ * Class ProcessorTest
+ * @package Dennis/Link/Checker
+ */
+class ProcessorTest extends PHPUnitTestCase {
+
+  /**
+   * @covers ::run
+   */
+  public function testRun() {
+
+    $logger = $this->getMockBuilder(Logger::class)
+      ->disableOriginalConstructor()
+      ->setMethods(['warning'])
+      ->getMock();
+    $logger->method('warning')->willReturn(TRUE);
+
+    $config = $this->getMockBuilder(Config::class)
+      ->disableOriginalConstructor()
+      ->setMethods(['getLogger'])
+      ->getMock();
+    $config->method('getLogger')->willReturn($logger);
+
+    $proc = $this->getMockBuilder(Processor::class)
+      ->disableOriginalConstructor()
+      ->setMethods(['doNextItem', 'ensureEnqueued', 'prune', 'inMaintenanceMode'])
+      ->getMock();
+    $proc->setConfig($config);
+    $proc->method('ensureEnqueued')->willReturn(TRUE);
+    $proc->method('prune')->willReturn(TRUE);
+    $proc->method('inMaintenanceMode')->willReturn(FALSE);
+
+    // Check it finishes cleanly when there are no more items left.
+    $proc->method('doNextItem')->willReturn(FALSE);
+    $this->assertTrue($proc->run());
+
+    // Check that the processor returns false on RequestTimeoutException.
+    $e = new RequestTimeoutException('timeout test', CURLOPT_TIMEOUT);
+    $proc->method('doNextItem')->willThrowException($e);
+    $this->assertFalse($proc->run());
+
+    // Check that it cannot run in maintenance mode.
+    $proc->method('inMaintenanceMode')->willReturn(TRUE);
+    $this->assertFalse($proc->run());
+
+  }
+
+}


### PR DESCRIPTION
- At the first request timeout stop running for this cron run.
- Statically cache links visited during the run so links do not need to be repeatedly checked.
- Unit tests for the above.